### PR TITLE
Support for 5.2 kernel

### DIFF
--- a/driver/product/kernel/drivers/gpu/arm/midgard/platform/meson/mali_kbase_runtime_pm.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/platform/meson/mali_kbase_runtime_pm.c
@@ -63,7 +63,11 @@ static int pm_soft_reset(struct kbase_device *kbdev)
 {
 	struct reset_control *rstc;
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 1, 0)
+	rstc = of_reset_control_array_get(kbdev->dev->of_node, false, false, false);
+#else
 	rstc = of_reset_control_array_get(kbdev->dev->of_node, false, false);
+#endif
 	if (!IS_ERR(rstc)) {
 		reset_control_assert(rstc);
 		udelay(10);

--- a/driver/product/kernel/drivers/gpu/arm/midgard/platform/meson/mali_kbase_runtime_pm.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/platform/meson/mali_kbase_runtime_pm.c
@@ -63,8 +63,8 @@ static int pm_soft_reset(struct kbase_device *kbdev)
 {
 	struct reset_control *rstc;
 
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 1, 0)
-	rstc = of_reset_control_array_get(kbdev->dev->of_node, false, false, false);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0)
+	rstc = of_reset_control_array_get(kbdev->dev->of_node, false, false, true);
 #else
 	rstc = of_reset_control_array_get(kbdev->dev->of_node, false, false);
 #endif


### PR DESCRIPTION
This fixes compile on 5.1 kernel (wrong minimum kernel version) and on 5.2 kernel (as the initial change from @superna9999 didn't work).