### PR TITLE
squash some warnings

### DIFF
--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_fence.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_fence.c
@@ -67,7 +67,7 @@ kbase_fence_fence_value_str(struct fence *fence, char *str, int size)
 kbase_fence_fence_value_str(struct dma_fence *fence, char *str, int size)
 #endif
 {
-	snprintf(str, size, "%u", fence->seqno);
+	snprintf(str, size, "%llu", fence->seqno);
 }
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync_file.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync_file.c
@@ -307,7 +307,7 @@ static void kbase_sync_fence_info_get(struct dma_fence *fence,
 	scnprintf(info->name, sizeof(info->name), "%u#%u",
 		  fence->context, fence->seqno);
 #else
-	scnprintf(info->name, sizeof(info->name), "%llu#%u",
+	scnprintf(info->name, sizeof(info->name), "%llu#%llu",
 		  fence->context, fence->seqno);
 #endif
 }


### PR DESCRIPTION
this fixes the following compiler warnings:

```
/home/chewitt/LibreELEC.chewitt/build.LibreELEC-AMLG12.arm-9.80.0/mali-bifrost-c56ef20e65d361a1964e3b86c03afad1f56491ae/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync_file.c: In function ‘kbase_sync_fence_info_get’:
/home/chewitt/LibreELEC.chewitt/build.LibreELEC-AMLG12.arm-9.80.0/mali-bifrost-c56ef20e65d361a1964e3b86c03afad1f56491ae/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync_file.c:310:51: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘u64’ {aka ‘long long unsigned int’} [-Wformat=]
  scnprintf(info->name, sizeof(info->name), "%llu#%u",
                                                  ~^
                                                  %llu
     fence->context, fence->seqno);
                     ~~~~~~~~~~~~                   
  CC [M]  /home/chewitt/LibreELEC.chewitt/build.LibreELEC-AMLG12.arm-9.80.0/mali-bifrost-c56ef20e65d361a1964e3b86c03afad1f56491ae/driver/product/kernel/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_gpu.o
/home/chewitt/LibreELEC.chewitt/build.LibreELEC-AMLG12.arm-9.80.0/mali-bifrost-c56ef20e65d361a1964e3b86c03afad1f56491ae/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_fence.c: In function ‘kbase_fence_fence_value_str’:
/home/chewitt/LibreELEC.chewitt/build.LibreELEC-AMLG12.arm-9.80.0/mali-bifrost-c56ef20e65d361a1964e3b86c03afad1f56491ae/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_fence.c:70:24: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘u64’ {aka ‘long long unsigned int’} [-Wformat=]
  snprintf(str, size, "%u", fence->seqno);
                       ~^   ~~~~~~~~~~~~
                       %llu
```